### PR TITLE
use `multi_get` for fetching transactions

### DIFF
--- a/scribe/db/db.py
+++ b/scribe/db/db.py
@@ -1013,7 +1013,7 @@ class HubDB:
                 branch, root = self.merkle.branch_and_root(
                     self.get_block_txs(tx_height), tx_pos
                 )
-                tx_infos[tx_hash_bytes[::-1].hex()] = None if not tx else tx.hex(), {
+                merkle = {
                     'block_height': tx_height,
                     'merkle': [
                         hash_to_hex_str(_hash)
@@ -1021,6 +1021,9 @@ class HubDB:
                     ],
                     'pos': tx_pos
                 }
+                tx_infos[tx_hash_bytes[::-1].hex()] = None if not tx else tx.hex(), merkle
+                if tx_height > 0 and tx_height + 10 < self.db_height:
+                    self._tx_and_merkle_cache[tx_hash_bytes[::-1].hex()] = tx, merkle
                 await asyncio.sleep(0)
         if needed_mempool:
             for tx_hash_bytes, tx in zip(needed_mempool, await run_in_executor(

--- a/scribe/db/db.py
+++ b/scribe/db/db.py
@@ -1005,13 +1005,24 @@ class HubDB:
                 await asyncio.sleep(0)
 
         if needed_confirmed:
+            needed_heights = set()
+            tx_heights_and_positions = {}
             for (tx_hash_bytes, tx_num), tx in zip(needed_confirmed, await run_in_executor(
                     self._executor, self.prefix_db.tx.multi_get, [(tx_hash,) for tx_hash, _ in needed_confirmed],
                     True, False)):
                 tx_height = bisect_right(self.tx_counts, tx_num)
+                needed_heights.add(tx_height)
                 tx_pos = tx_num - self.tx_counts[tx_height - 1]
+                tx_heights_and_positions[tx_hash_bytes] = (tx, tx_num, tx_height, tx_pos)
+
+            sorted_heights = list(sorted(needed_heights))
+            block_txs = await run_in_executor(
+                self._executor, self.prefix_db.block_txs.multi_get, [(height,) for height in sorted_heights]
+            )
+            block_txs = {height: v.tx_hashes for height, v in zip(sorted_heights, block_txs)}
+            for tx_hash_bytes, (tx, tx_num, tx_height, tx_pos) in tx_heights_and_positions.items():
                 branch, root = self.merkle.branch_and_root(
-                    self.get_block_txs(tx_height), tx_pos
+                    block_txs[tx_height], tx_pos
                 )
                 merkle = {
                     'block_height': tx_height,

--- a/scribe/db/interface.py
+++ b/scribe/db/interface.py
@@ -90,12 +90,9 @@ class PrefixRow(metaclass=PrefixRowType):
 
     def multi_get(self, key_args: typing.List[typing.Tuple], fill_cache=True, deserialize_value=True):
         packed_keys = {tuple(args): self.pack_key(*args) for args in key_args}
-        result = {
-            k[-1]: v for k, v in (
-                self._db.multi_get([(self._column_family, packed_keys[tuple(args)]) for args in key_args],
-                                   fill_cache=fill_cache) or {}
-            ).items()
-        }
+        db_result = self._db.multi_get([(self._column_family, packed_keys[tuple(args)]) for args in key_args],
+                                   fill_cache=fill_cache)
+        result = {k[-1]: v for k, v in (db_result or {}).items()}
 
         def handle_value(v):
             return None if v is None else v if not deserialize_value else self.unpack_value(v)

--- a/scribe/elasticsearch/service.py
+++ b/scribe/elasticsearch/service.py
@@ -231,7 +231,7 @@ class ElasticSyncService(BlockchainReaderService):
         self._advanced = True
 
     def unwind(self):
-        reverted_block_hash = self.db.coin.header_hash(self.db.headers[-1])
+        reverted_block_hash = self.db.block_hashes[-1]
         super().unwind()
         packed = self.db.prefix_db.undo.get(len(self.db.tx_counts), reverted_block_hash)
         touched_or_deleted = None

--- a/scribe/service.py
+++ b/scribe/service.py
@@ -157,7 +157,9 @@ class BlockchainReaderService(BlockchainService):
                 self.db.total_transactions.append(tx_hash)
                 self.db.tx_num_mapping[tx_hash] = tx_count
             assert len(self.db.total_transactions) == tx_count, f"{len(self.db.total_transactions)} vs {tx_count}"
-        self.db.headers.append(self.db.prefix_db.header.get(height, deserialize_value=False))
+        header = self.db.prefix_db.header.get(height, deserialize_value=False)
+        self.db.headers.append(header)
+        self.db.block_hashes.append(self.env.coin.header_hash(header))
 
     def unwind(self):
         """
@@ -166,6 +168,7 @@ class BlockchainReaderService(BlockchainService):
         prev_count = self.db.tx_counts.pop()
         tx_count = self.db.tx_counts[-1]
         self.db.headers.pop()
+        self.db.block_hashes.pop()
         if self.db._cache_all_tx_hashes:
             for _ in range(prev_count - tx_count):
                 self.db.tx_num_mapping.pop(self.db.total_transactions.pop())


### PR DESCRIPTION
This improves the performance of `HubDB.get_transactions_and_merkles` - both when fetching the transactions and when generating the merkle proofs. The speedup with  `blockchain.transaction.get_batch` is significant with batches of transactions mostly in the same block.

- uses `multi_get` when preparing to fetch and when actually fetching transactions
- batch merkle proof generation by block
