### PR TITLE
Expose `--index_address_statuses` setting and improve first sync performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For various reasons it may be desirable to block or filtering content from claim
 
 #### Options for `scribe`
   - `--db_max_open_files` This setting translates into the max_open_files option given to rocksdb. A higher number will use more memory. Defaults to 64.
+  - `--address_history_cache_size` The count of items in the address history cache used for processing blocks and mempool updates. A higher number will use more memory, shouldn't ever need to be higher than 10000. Defaults to 1000.
 
 #### Options for `scribe-elastic-sync`
   - `--reindex` If this flag is set drop and rebuild the elasticsearch index.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ For various reasons it may be desirable to block or filtering content from claim
 #### Options for `scribe`
   - `--db_max_open_files` This setting translates into the max_open_files option given to rocksdb. A higher number will use more memory. Defaults to 64.
   - `--address_history_cache_size` The count of items in the address history cache used for processing blocks and mempool updates. A higher number will use more memory, shouldn't ever need to be higher than 10000. Defaults to 1000.
+  - `--index_address_statuses` Maintain an index of the statuses of address transaction histories, this makes handling notifications for transactions in a block uniformly fast at the expense of more time to process new blocks and somewhat more disk space (~10gb as of block 1161417).
 
 #### Options for `scribe-elastic-sync`
   - `--reindex` If this flag is set drop and rebuild the elasticsearch index.
@@ -104,6 +105,7 @@ For various reasons it may be desirable to block or filtering content from claim
   - `--query_timeout_ms` Timeout for claim searches in elasticsearch in milliseconds. Can be set from the environment with `QUERY_TIMEOUT_MS`
   - `--blocking_channel_ids` Space separated list of channel claim ids used for blocking. Claims that are reposted by these channels can't be resolved or returned in search results. Can be set from the environment with `BLOCKING_CHANNEL_IDS`.
   - `--filtering_channel_ids` Space separated list of channel claim ids used for blocking. Claims that are reposted by these channels aren't returned in search results. Can be set from the environment with `FILTERING_CHANNEL_IDS`
+  - `--index_address_statuses` Use the address history status index, this makes handling notifications for transactions in a block uniformly fast (must be turned on in `scribe` too).
 
 ## Contributing
 

--- a/scribe/blockchain/daemon.py
+++ b/scribe/blockchain/daemon.py
@@ -55,8 +55,8 @@ class LBCDaemon:
         self._height = None
         self.available_rpcs = {}
         self.connector = aiohttp.TCPConnector(ssl=False)
-        self._block_hash_cache = LRUCacheWithMetrics(100000)
-        self._block_cache = LRUCacheWithMetrics(2 ** 13, metric_name='block', namespace=NAMESPACE)
+        self._block_hash_cache = LRUCacheWithMetrics(1024)
+        self._block_cache = LRUCacheWithMetrics(64, metric_name='block', namespace=NAMESPACE)
 
     async def close(self):
         if self.connector:

--- a/scribe/blockchain/env.py
+++ b/scribe/blockchain/env.py
@@ -6,14 +6,15 @@ class BlockchainEnv(Env):
                  prometheus_port=None, cache_all_tx_hashes=None, cache_all_claim_txos=None,
                  blocking_channel_ids=None, filtering_channel_ids=None,
                  db_max_open_files=64, daemon_url=None, hashX_history_cache_size=None,
-                 index_address_status=None):
+                 index_address_status=None, rebuild_address_status_from_height=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
                          cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.db_max_open_files = db_max_open_files
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
         self.hashX_history_cache_size = hashX_history_cache_size if hashX_history_cache_size is not None \
             else self.integer('ADDRESS_HISTORY_CACHE_SIZE', 1000)
-
+        self.rebuild_address_status_from_height = rebuild_address_status_from_height \
+            if isinstance(rebuild_address_status_from_height, int) else -1
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -31,6 +32,9 @@ class BlockchainEnv(Env):
                             help="LRU cache size for address histories, used when processing new blocks "
                                  "and when processing mempool updates. Can be set in env with "
                                  "'ADDRESS_HISTORY_CACHE_SIZE'")
+        parser.add_argument('--rebuild_address_status_from_height', type=int, default=-1,
+                            help="Rebuild address statuses, set to 0 to reindex all address statuses or provide a "
+                                 "block height to start reindexing from. Defaults to -1 (off).")
 
     @classmethod
     def from_arg_parser(cls, args):
@@ -39,5 +43,6 @@ class BlockchainEnv(Env):
             max_query_workers=args.max_query_workers, chain=args.chain, reorg_limit=args.reorg_limit,
             prometheus_port=args.prometheus_port, cache_all_tx_hashes=args.cache_all_tx_hashes,
             cache_all_claim_txos=args.cache_all_claim_txos, index_address_status=args.index_address_statuses,
-            hashX_history_cache_size=args.address_history_cache_size
+            hashX_history_cache_size=args.address_history_cache_size,
+            rebuild_address_status_from_height=args.rebuild_address_status_from_height
         )

--- a/scribe/blockchain/env.py
+++ b/scribe/blockchain/env.py
@@ -5,13 +5,15 @@ class BlockchainEnv(Env):
     def __init__(self, db_dir=None, max_query_workers=None, chain=None, reorg_limit=None,
                  prometheus_port=None, cache_all_tx_hashes=None, cache_all_claim_txos=None,
                  blocking_channel_ids=None, filtering_channel_ids=None,
-                 db_max_open_files=64, daemon_url=None, hashX_history_cache_size=None):
+                 db_max_open_files=64, daemon_url=None, hashX_history_cache_size=None,
+                 index_address_status=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
-                         cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids)
+                         cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.db_max_open_files = db_max_open_files
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
         self.hashX_history_cache_size = hashX_history_cache_size if hashX_history_cache_size is not None \
             else self.integer('ADDRESS_HISTORY_CACHE_SIZE', 1000)
+
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):

--- a/scribe/blockchain/env.py
+++ b/scribe/blockchain/env.py
@@ -5,11 +5,13 @@ class BlockchainEnv(Env):
     def __init__(self, db_dir=None, max_query_workers=None, chain=None, reorg_limit=None,
                  prometheus_port=None, cache_all_tx_hashes=None, cache_all_claim_txos=None,
                  blocking_channel_ids=None, filtering_channel_ids=None,
-                 db_max_open_files=64, daemon_url=None):
+                 db_max_open_files=64, daemon_url=None, hashX_history_cache_size=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
                          cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids)
         self.db_max_open_files = db_max_open_files
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
+        self.hashX_history_cache_size = hashX_history_cache_size if hashX_history_cache_size is not None \
+            else self.integer('ADDRESS_HISTORY_CACHE_SIZE', 1000)
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -22,6 +24,11 @@ class BlockchainEnv(Env):
         parser.add_argument('--db_max_open_files', type=int, default=64,
                             help='This setting translates into the max_open_files option given to rocksdb. '
                                  'A higher number will use more memory. Defaults to 64.')
+        parser.add_argument('--address_history_cache_size', type=int,
+                            default=cls.integer('ADDRESS_HISTORY_CACHE_SIZE', 1000),
+                            help="LRU cache size for address histories, used when processing new blocks "
+                                 "and when processing mempool updates. Can be set in env with "
+                                 "'ADDRESS_HISTORY_CACHE_SIZE'")
 
     @classmethod
     def from_arg_parser(cls, args):

--- a/scribe/blockchain/env.py
+++ b/scribe/blockchain/env.py
@@ -38,5 +38,6 @@ class BlockchainEnv(Env):
             db_dir=args.db_dir, daemon_url=args.daemon_url, db_max_open_files=args.db_max_open_files,
             max_query_workers=args.max_query_workers, chain=args.chain, reorg_limit=args.reorg_limit,
             prometheus_port=args.prometheus_port, cache_all_tx_hashes=args.cache_all_tx_hashes,
-            cache_all_claim_txos=args.cache_all_claim_txos
+            cache_all_claim_txos=args.cache_all_claim_txos, index_address_status=args.index_address_statuses,
+            hashX_history_cache_size=args.address_history_cache_size
         )

--- a/scribe/blockchain/service.py
+++ b/scribe/blockchain/service.py
@@ -118,7 +118,7 @@ class BlockchainProcessorService(BlockchainService):
 
         self.hashX_history_cache = LRUCache(min(100, max(0, env.hashX_history_cache_size)))
         self.hashX_full_cache = LRUCache(min(100, max(0, env.hashX_history_cache_size)))
-        self.history_tx_info_cache = LRUCache(2 ** 20)
+        self.history_tx_info_cache = LRUCache(2 ** 16)
 
     async def run_in_thread_with_lock(self, func, *args):
         # Run in a thread to prevent blocking.  Shielded so that

--- a/scribe/blockchain/service.py
+++ b/scribe/blockchain/service.py
@@ -1693,6 +1693,8 @@ class BlockchainProcessorService(BlockchainService):
             self._ready_to_stop.set()
 
     async def _need_catch_up(self):
+        self.log.info("database has fallen behind blockchain daemon, catching up")
+
         self.db.catching_up = True
 
         def flush():
@@ -1706,8 +1708,8 @@ class BlockchainProcessorService(BlockchainService):
     async def _finished_initial_catch_up(self):
         self.log.info(f'caught up to height {self.height}')
 
-        # if self.env.index_address_status and self.db.last_indexed_address_status_height != self.db.db_height:
-        #     await self.db.rebuild_hashX_status_index(self.db.last_indexed_address_status_height)
+        if self.env.index_address_status and self.db.last_indexed_address_status_height < self.db.db_height:
+            await self.db.rebuild_hashX_status_index(self.db.last_indexed_address_status_height)
 
         # Flush everything but with catching_up->False state.
         self.db.catching_up = False

--- a/scribe/db/db.py
+++ b/scribe/db/db.py
@@ -39,7 +39,8 @@ class HubDB:
     def __init__(self, coin, db_dir: str, reorg_limit: int = 200,
                  cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,
                  secondary_name: str = '', max_open_files: int = 64, blocking_channel_ids: List[str] = None,
-                 filtering_channel_ids: List[str] = None, executor: ThreadPoolExecutor = None):
+                 filtering_channel_ids: List[str] = None, executor: ThreadPoolExecutor = None,
+                 index_address_status=False):
         self.logger = logging.getLogger(__name__)
         self.coin = coin
         self._executor = executor
@@ -52,6 +53,7 @@ class HubDB:
         if secondary_name:
             assert max_open_files == -1, 'max open files must be -1 for secondary readers'
         self._db_max_open_files = max_open_files
+        self._index_address_status = index_address_status
         self.prefix_db: typing.Optional[PrefixDB] = None
 
         self.hist_unflushed = defaultdict(partial(array.array, 'I'))

--- a/scribe/db/db.py
+++ b/scribe/db/db.py
@@ -864,13 +864,16 @@ class HubDB:
         self.prefix_db.close()
         self.prefix_db = None
 
-    def get_hashX_status(self, hashX: bytes):
+    def _get_hashX_status(self, hashX: bytes):
         mempool_status = self.prefix_db.hashX_mempool_status.get(hashX, deserialize_value=False)
         if mempool_status:
             return mempool_status.hex()
         status = self.prefix_db.hashX_status.get(hashX, deserialize_value=False)
         if status:
             return status.hex()
+
+    async def get_hashX_status(self, hashX: bytes):
+        return await asyncio.get_event_loop().run_in_executor(self._executor, self._get_hashX_status, hashX)
 
     def get_tx_hash(self, tx_num: int) -> bytes:
         if self._cache_all_tx_hashes:

--- a/scribe/db/db.py
+++ b/scribe/db/db.py
@@ -828,6 +828,8 @@ class HubDB:
         # read db state
         self.read_db_state()
 
+        self.logger.info("index address statuses: %s", self._index_address_status)
+
         # These are our state as we move ahead of DB state
         self.fs_height = self.db_height
         self.fs_tx_count = self.db_tx_count

--- a/scribe/db/db.py
+++ b/scribe/db/db.py
@@ -18,7 +18,7 @@ from scribe.schema.url import URL, normalize_name
 from scribe.schema.claim import guess_stream_type
 from scribe.schema.result import Censor
 from scribe.blockchain.transaction import TxInput
-from scribe.common import hash_to_hex_str, hash160, LRUCacheWithMetrics
+from scribe.common import hash_to_hex_str, hash160, LRUCacheWithMetrics, sha256
 from scribe.db.merkle import Merkle, MerkleCache, FastMerkleCacheItem
 from scribe.db.common import ResolveResult, STREAM_TYPES, CLAIM_TYPES, ExpandedResolveResult, DBError, UTXO
 from scribe.db.prefixes import PendingActivationValue, ClaimTakeoverValue, ClaimToTXOValue, PrefixDB
@@ -34,7 +34,7 @@ NAMESPACE = f"{PROMETHEUS_NAMESPACE}_db"
 
 
 class HubDB:
-    DB_VERSIONS = [7, 8]
+    DB_VERSIONS = [7, 8, 9]
 
     def __init__(self, coin, db_dir: str, reorg_limit: int = 200,
                  cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,
@@ -63,6 +63,7 @@ class HubDB:
         self.hist_comp_cursor = -1
 
         self.es_sync_height = 0
+        self.last_indexed_address_status_height = 0
 
         # blocking/filtering dicts
         blocking_channels = blocking_channel_ids or []
@@ -864,6 +865,78 @@ class HubDB:
         self.prefix_db.close()
         self.prefix_db = None
 
+    def _rebuild_hashX_status_index(self, start_height: int):
+        self.logger.warning("rebuilding the address status index...")
+        prefix_db = self.prefix_db
+
+        def hashX_iterator():
+            last_hashX = None
+            for k in prefix_db.hashX_history.iterate(deserialize_key=False, include_value=False):
+                hashX = k[1:12]
+                if last_hashX is None:
+                    last_hashX = hashX
+                if last_hashX != hashX:
+                    yield hashX
+                    last_hashX = hashX
+            if last_hashX:
+                yield last_hashX
+
+        def hashX_status_from_history(history: bytes) -> bytes:
+            tx_counts = self.tx_counts
+            hist_tx_nums = array.array('I')
+            hist_tx_nums.frombytes(history)
+            hist = ''
+            for tx_num in hist_tx_nums:
+                hist += f'{self.get_tx_hash(tx_num)[::-1].hex()}:{bisect_right(tx_counts, tx_num)}:'
+            return sha256(hist.encode())
+
+        start = time.perf_counter()
+
+        if start_height <= 0:
+            self.logger.info("loading all blockchain addresses, this will take a little while...")
+            hashXs = [hashX for hashX in hashX_iterator()]
+        else:
+            self.logger.info("loading addresses since block %i...", start_height)
+            hashXs = set()
+            for touched in prefix_db.touched_hashX.iterate(start=(start_height,), stop=(self.db_height + 1,),
+                                                           include_key=False):
+                hashXs.update(touched.touched_hashXs)
+            hashXs = list(hashXs)
+
+        self.logger.info(f"loaded {len(hashXs)} hashXs in {round(time.perf_counter() - start, 2)}s, "
+                         f"now building the status index...")
+        op_cnt = 0
+        hashX_cnt = 0
+        for hashX in hashXs:
+            hashX_cnt += 1
+            key = prefix_db.hashX_status.pack_key(hashX)
+            history = b''.join(prefix_db.hashX_history.iterate(prefix=(hashX,), deserialize_value=False, include_key=False))
+            status = hashX_status_from_history(history)
+            existing_status = prefix_db.hashX_status.get(hashX, deserialize_value=False)
+            if existing_status and existing_status == status:
+                continue
+            elif not existing_status:
+                prefix_db.stage_raw_put(key, status)
+                op_cnt += 1
+            else:
+                prefix_db.stage_raw_delete(key, existing_status)
+                prefix_db.stage_raw_put(key, status)
+                op_cnt += 2
+            if op_cnt > 100000:
+                prefix_db.unsafe_commit()
+                self.logger.info(f"wrote {hashX_cnt}/{len(hashXs)} hashXs statuses...")
+                op_cnt = 0
+        if op_cnt:
+            prefix_db.unsafe_commit()
+            self.logger.info(f"wrote {hashX_cnt}/{len(hashXs)} hashXs statuses...")
+        self._index_address_status = True
+        self.write_db_state()
+        self.prefix_db.unsafe_commit()
+        self.logger.info("finished indexing address statuses")
+
+    def rebuild_hashX_status_index(self, start_height: int):
+        return asyncio.get_event_loop().run_in_executor(self._executor, self._rebuild_hashX_status_index, start_height)
+
     def _get_hashX_status(self, hashX: bytes):
         mempool_status = self.prefix_db.hashX_mempool_status.get(hashX, deserialize_value=False)
         if mempool_status:
@@ -1126,13 +1199,18 @@ class HubDB:
 
     def write_db_state(self):
         """Write (UTXO) state to the batch."""
+        last_indexed_address_status = 0
         if self.db_height > 0:
-            self.prefix_db.db_state.stage_delete((), self.prefix_db.db_state.get())
+            existing = self.prefix_db.db_state.get()
+            last_indexed_address_status = existing.hashX_status_last_indexed_height
+            self.prefix_db.db_state.stage_delete((), existing.expanded)
+        if self._index_address_status:
+            last_indexed_address_status = self.db_height
         self.prefix_db.db_state.stage_put((), (
             self.genesis_bytes, self.db_height, self.db_tx_count, self.db_tip,
-            self.utxo_flush_count, int(self.wall_time), self.catching_up, self.db_version,
+            self.utxo_flush_count, int(self.wall_time), self.catching_up, self._index_address_status, self.db_version,
             self.hist_flush_count, self.hist_comp_flush_count, self.hist_comp_cursor,
-            self.es_sync_height
+            self.es_sync_height, last_indexed_address_status
             )
         )
 
@@ -1152,6 +1230,7 @@ class HubDB:
             self.hist_comp_cursor = -1
             self.hist_db_version = max(self.DB_VERSIONS)
             self.es_sync_height = 0
+            self.last_indexed_address_status_height = 0
         else:
             self.db_version = state.db_version
             if self.db_version not in self.DB_VERSIONS:
@@ -1173,6 +1252,7 @@ class HubDB:
             self.hist_comp_cursor = state.comp_cursor
             self.hist_db_version = state.db_version
             self.es_sync_height = state.es_sync_height
+            self.last_indexed_address_status_height = state.hashX_status_last_indexed_height
         return state
 
     def assert_db_state(self):

--- a/scribe/db/db.py
+++ b/scribe/db/db.py
@@ -83,7 +83,7 @@ class HubDB:
         self.tx_counts = None
         self.headers = None
         self.block_hashes = None
-        self.encoded_headers = LRUCacheWithMetrics(1 << 21, metric_name='encoded_headers', namespace=NAMESPACE)
+        self.encoded_headers = LRUCacheWithMetrics(1024, metric_name='encoded_headers', namespace=NAMESPACE)
         self.last_flush = time.time()
 
         # Header merkle cache

--- a/scribe/db/migrators/migrate8to9.py
+++ b/scribe/db/migrators/migrate8to9.py
@@ -1,0 +1,26 @@
+import logging
+
+FROM_VERSION = 8
+TO_VERSION = 9
+
+
+def migrate(db):
+    log = logging.getLogger(__name__)
+    prefix_db = db.prefix_db
+    index_address_status = db._index_address_status
+
+    log.info("migrating the db to version 9")
+
+    if not index_address_status:
+        log.info("deleting the existing address status index")
+        to_delete = list(prefix_db.hashX_status.iterate(deserialize_key=False, deserialize_value=False))
+        while to_delete:
+            batch, to_delete = to_delete[:10000], to_delete[10000:]
+            if batch:
+                prefix_db.multi_delete(batch)
+                prefix_db.unsafe_commit()
+
+    db.db_version = 9
+    db.write_db_state()
+    db.prefix_db.unsafe_commit()
+    log.info("finished migration")

--- a/scribe/env.py
+++ b/scribe/env.py
@@ -31,7 +31,7 @@ class Env:
 
     def __init__(self, db_dir=None, max_query_workers=None, chain=None, reorg_limit=None,
                  prometheus_port=None, cache_all_tx_hashes=None, cache_all_claim_txos=None,
-                 blocking_channel_ids=None, filtering_channel_ids=None):
+                 blocking_channel_ids=None, filtering_channel_ids=None, index_address_status=None):
 
         self.logger = logging.getLogger(__name__)
         self.db_dir = db_dir if db_dir is not None else self.required('DB_DIRECTORY')
@@ -52,6 +52,8 @@ class Env:
             'BLOCKING_CHANNEL_IDS', '').split(' ')
         self.filtering_channel_ids = filtering_channel_ids if filtering_channel_ids is not None else self.default(
             'FILTERING_CHANNEL_IDS', '').split(' ')
+        self.index_address_status = index_address_status if index_address_status is not None else \
+            self.boolean('INDEX_ADDRESS_STATUS', False)
 
     @classmethod
     def default(cls, envvar, default):
@@ -187,6 +189,12 @@ class Env:
                                  "Claims that are reposted by these channels aren't returned in search results. "
                                  "Can be set in env with 'FILTERING_CHANNEL_IDS'",
                             default=cls.default('FILTERING_CHANNEL_IDS', '').split(' '))
+        parser.add_argument('--index_address_statuses', action='store_true',
+                            help="Use precomputed address statuses, must be enabled in the reader and the writer to "
+                                 "use it. If disabled (the default), the status of an address must be calculated at "
+                                 "runtime when clients request it (address subscriptions, address history sync). "
+                                 "If enabled, scribe will maintain an index of precomputed statuses",
+                            default=cls.boolean('INDEX_ADDRESS_STATUS', False))
 
     @classmethod
     def from_arg_parser(cls, args):

--- a/scribe/hub/env.py
+++ b/scribe/hub/env.py
@@ -10,9 +10,10 @@ class ServerEnv(Env):
                  payment_address=None, donation_address=None, max_send=None, max_receive=None, max_sessions=None,
                  session_timeout=None, drop_client=None, description=None, daily_fee=None,
                  database_query_timeout=None, elastic_notifier_host=None, elastic_notifier_port=None,
-                 blocking_channel_ids=None, filtering_channel_ids=None, peer_hubs=None, peer_announce=None):
+                 blocking_channel_ids=None, filtering_channel_ids=None, peer_hubs=None, peer_announce=None,
+                 index_address_status=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
-                         cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids)
+                         cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
         self.host = host if host is not None else self.default('HOST', 'localhost')
         self.elastic_host = elastic_host if elastic_host is not None else self.default('ELASTIC_HOST', 'localhost')
@@ -109,5 +110,5 @@ class ServerEnv(Env):
             drop_client=args.drop_client, description=args.description, daily_fee=args.daily_fee,
             database_query_timeout=args.query_timeout_ms, blocking_channel_ids=args.blocking_channel_ids,
             filtering_channel_ids=args.filtering_channel_ids, elastic_notifier_host=args.elastic_notifier_host,
-            elastic_notifier_port=args.elastic_notifier_port
+            elastic_notifier_port=args.elastic_notifier_port, index_address_status=args.index_address_statuses
         )

--- a/scribe/hub/mempool.py
+++ b/scribe/hub/mempool.py
@@ -157,6 +157,14 @@ class HubMemPool:
             result.append(MemPoolTxSummary(tx_hash, tx.fee, has_ui))
         return result
 
+    def mempool_history(self, hashX: bytes) -> str:
+        result = ''
+        for tx_hash in self.touched_hashXs.get(hashX, ()):
+            if tx_hash not in self.txs:
+                continue  # the tx hash for the touched address is an input that isn't in mempool anymore
+            result += f'{tx_hash[::-1].hex()}:{-any(_hash in self.txs for _hash, idx in self.txs[tx_hash].in_pairs):d}:'
+        return result
+
     def unordered_UTXOs(self, hashX):
         """Return an unordered list of UTXO named tuples from mempool
         transactions that pay to hashX.
@@ -276,7 +284,6 @@ class HubMemPool:
             if session.subscribe_headers and height_changed:
                 sent_headers += 1
             self._notification_q.put_nowait((session_id, height_changed, hashXes))
-
         if sent_headers:
             self.logger.info(f'notified {sent_headers} sessions of new block header')
         if session_hashxes_to_notify:

--- a/scribe/hub/session.py
+++ b/scribe/hub/session.py
@@ -1089,10 +1089,8 @@ class LBRYElectrumX(asyncio.Protocol):
         return len(self.hashX_subs)
 
     async def get_hashX_status(self, hashX: bytes):
-        self.session_manager.db.last_flush
         if self.env.index_address_status:
-            loop = self.loop
-            return await loop.run_in_executor(None, self.db.get_hashX_status, hashX)
+            return await self.db.get_hashX_status(hashX)
         history = ''.join(
             f"{tx_hash[::-1].hex()}:{height:d}:"
             for tx_hash, height in await self.db.limited_history(hashX, limit=None)

--- a/scribe/hub/session.py
+++ b/scribe/hub/session.py
@@ -1089,7 +1089,18 @@ class LBRYElectrumX(asyncio.Protocol):
         return len(self.hashX_subs)
 
     async def get_hashX_status(self, hashX: bytes):
-        return await self.loop.run_in_executor(self.db._executor, self.db.get_hashX_status, hashX)
+        self.session_manager.db.last_flush
+        if self.env.index_address_status:
+            loop = self.loop
+            return await loop.run_in_executor(None, self.db.get_hashX_status, hashX)
+        history = ''.join(
+            f"{tx_hash[::-1].hex()}:{height:d}:"
+            for tx_hash, height in await self.db.limited_history(hashX, limit=None)
+        ) + self.mempool.mempool_history(hashX)
+        if not history:
+            return
+        status = sha256(history.encode())
+        return status.hex()
 
     async def send_history_notifications(self, *hashXes: typing.Iterable[bytes]):
         notifications = []

--- a/scribe/service.py
+++ b/scribe/service.py
@@ -30,7 +30,8 @@ class BlockchainService:
         self.db = HubDB(
             env.coin, env.db_dir, env.reorg_limit, env.cache_all_claim_txos, env.cache_all_tx_hashes,
             secondary_name=secondary_name, max_open_files=-1, blocking_channel_ids=env.blocking_channel_ids,
-            filtering_channel_ids=env.filtering_channel_ids, executor=self._executor
+            filtering_channel_ids=env.filtering_channel_ids, executor=self._executor,
+            index_address_status=env.index_address_status
         )
         self._stopping = False
 


### PR DESCRIPTION
- adds `--index_address_statuses` flag, off by default. This is used to turn on/off the index of status hashes for addresses added in https://github.com/lbryio/scribe/pull/17 to allow scribe to run with fewer resources necessary. The index adds ~10gb to the database, it makes processing new blocks slower but makes handling the notifications for the addresses touched by transactions in the block much faster.
- add internal caches to handle updating address statuses and reading address histories faster without needing `--cache_all_tx_hashes` to be on
- sync the address status index ( `--index_address_statuses` ) when caught up after startup, including after first initial-sync.
- refactors and combines updating and compacting the address history to be more performant, running in one pass, and use the rocksdb multi_get api
